### PR TITLE
Fix bug where findMetaNodes wouldn't search within namespaces.

### DIFF
--- a/src/pymetanode/scripts/pymetanode/utils.py
+++ b/src/pymetanode/scripts/pymetanode/utils.py
@@ -81,7 +81,7 @@ def getMObjectsByPlug(plugName):
     """
     sel = api.MSelectionList()
     try:
-        sel.add('*.' + plugName)
+        sel.add('*.' + plugName, True)
     except:
         pass
     count = sel.length()


### PR DESCRIPTION
If you had a node named something like "test:pSphere1", findMetaNodes wouldn't find the metadata for that node.